### PR TITLE
bower install

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server/server.js",
   "scripts": {
     "pretest": "jshint .",
-    "postinstall": "./node_modules/bower/bin/bower install"
+    "postinstall": "bower install"
   },
   "dependencies": {
     "bower": "^1.3.12",


### PR DESCRIPTION
./npm_modules/../anything breaks on windows.
bower install  as a suggestion
note that the README.md states that one should do a bower install: but this is done already in the package.json that is the target for this patch