### PR TITLE
root.js and static files

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,9 @@ In this directory, create [`styles.css`](/client/css/styles.css).
 
 ###9. Serve static assets from the `client` directory
 
-Remove the contents of [`routes`](/server/middleware.json#L14-L15) property and
+Ensure that no routes from slc loopback are installed in /server/boot eg root.js. 
+
+Remove the contents of [`routes`](/server/middleware.json#L14-L15) property (if present) and
 add static middleware to the [`files`](/server/middleware.json#L17-L19) section
 in [`middleware.json`](/server/middleware.json).
 


### PR DESCRIPTION
Add comment to check for root.js and possible removal of routes in middleware

slc loopback may have changed behaviour since the creation of this tutorial. On my setup a slc loopback created a root.js and no routes property.

This patch add comments concerning this BUTas a new user of strongloop / loopback, the offender is slc loopback :: I do not like boot/root.js and prefer use of middleware definition ...